### PR TITLE
Added Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Cobblemon Transporter/venv/**

--- a/Cobblemon Transporter/install.sh
+++ b/Cobblemon Transporter/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+sudo apt install python3-tk -y
+python3 -m venv venv
+source venv/bin/activate
+pip install nbtlib requests pillow tkinterdnd2

--- a/Cobblemon Transporter/linux.txt
+++ b/Cobblemon Transporter/linux.txt
@@ -1,0 +1,5 @@
+Cobblemon-Transporter seems to work well enough with Linux when using wine for the bundled Windows binaries.
+~/.winepkhex must exist and must have dotnetdesktop9 installed already. This wineprefix can be shared between Cobblemon-Transporter and PKHeX on Linux, thus saving disk space.
+
+An example of installing dotnetdesktop9 would look like this, run from your terminal on Linux:
+env WINEPREFIX=/home/$USER/.winepkhex winetricks dotnetdesktop9

--- a/Cobblemon Transporter/modules/PokemonImporter.py
+++ b/Cobblemon Transporter/modules/PokemonImporter.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tkinter as tk
 from tkinter import messagebox, filedialog
 
@@ -49,7 +50,21 @@ if not os.path.exists(pokemon_directory):
 
 # Loop through the selected files and run PB8ToJson.exe on each
 for pb8_file in pb8_files:
-    # Run the converter
-    subprocess.run([pb8_to_json_exe, pb8_file])
+    if sys.platform.startswith("linux"):
+        # We must have dotnetdesktop 9 installed in our wine prefix prior to running this
+        subprocess.run(
+            [
+                "/opt/wine-staging/bin/wine",
+                pb8_to_json_exe,
+                pb8_file
+            ],
+            env={
+                **os.environ,
+                "WINEPREFIX": os.path.expanduser("~/.winepkhex"),
+                "DOTNET_BUNDLE_EXTRACT_BASE_DIR": ""
+            }
+        )
+    else:
+        subprocess.run([pb8_to_json_exe, pb8_file])
 
 print("Conversion completed.")

--- a/Cobblemon Transporter/pokemonpc.py
+++ b/Cobblemon Transporter/pokemonpc.py
@@ -34,6 +34,31 @@ COLORS = {
     "dropdown_hover": "#EAF0F6"   # Light blue for dropdown hover
 }
 
+def run_windows_exe(exe_path, args, *, check=True, capture_output=False, text=True):
+    """
+    Run a Windows .exe on Linux/macOS via wine, or directly on Windows.
+    args: list of arguments (NOT including exe_path)
+    """
+    cmd = [exe_path] + list(args)
+
+    # If we're on Linux/macOS, run via wine.
+    if not sys.platform.startswith("win"):
+        cmd = [
+            "env",
+            "WINEPREFIX=" + os.path.expanduser("~/.winepkhex"),
+            "DOTNET_BUNDLE_EXTRACT_BASE_DIR=",
+            "wine",
+            exe_path,
+        ] + list(args)
+
+    # Use subprocess.run; caller decides whether to capture output.
+    return subprocess.run(
+        cmd,
+        check=check,
+        capture_output=capture_output,
+        text=text
+    )
+
 def create_rounded_rectangle(self, x1, y1, x2, y2, radius=25, **kwargs):
     points = [x1+radius, y1,
               x1+radius, y1,
@@ -319,7 +344,7 @@ class PokemonHomeApp:
             os.makedirs(self.current_folder)
         
         # Run the executable with file path and output directory
-        subprocess.run([pb8_to_json_exe, file_path, "--output", self.current_folder])
+        run_windows_exe(pb8_to_json_exe, [file_path, "--output", self.current_folder], check=False)
         
         # Find the newly created JSON file
         try:
@@ -549,7 +574,7 @@ class PokemonHomeApp:
             os.makedirs(self.current_folder)
         
         # Run the executable with file path and output directory
-        subprocess.run([pb8_to_json_exe, file_path, "--output", self.current_folder])
+        run_windows_exe(pb8_to_json_exe, [file_path, "--output", self.current_folder], check=False)
         
         # Find the newly created JSON file and modify its box/slot information
         try:
@@ -1440,7 +1465,7 @@ class PokemonHomeApp:
             self.update_status(f"Converting {self.selected_pokemon['species']} to .cb9...")
             
             # Run the converter .exe with the JSON file as an argument
-            subprocess.run([converter_exe, json_file_path], check=True)
+            run_windows_exe(converter_exe, [json_file_path], check=True)
             
             # Show success message
             messagebox.showinfo("Success", f"Conversion successful: {os.path.basename(json_file_path)}.cb9 created!")
@@ -1616,7 +1641,7 @@ class PokemonHomeApp:
             try:
                 # Run the converter .exe with the JSON file as an argument
                 self.update_status(f"Converting {os.path.basename(json_file_path)}...")
-                subprocess.run([converter_exe, json_file_path], check=True)
+                run_windows_exe(converter_exe, [json_file_path], check=True)
                 successful += 1
             except subprocess.CalledProcessError:
                 failed += 1

--- a/Cobblemon Transporter/pokemonpc.py
+++ b/Cobblemon Transporter/pokemonpc.py
@@ -235,7 +235,7 @@ class PokemonHomeApp:
             
             # Supported file extensions
             supported_extensions = {
-                '.pk9', '.cb9', '.pa9', '.pb8', '.pk8', '.pk7', '.pb7', '.pk6', '.pk5', '.pk4', '.pk3', '.dat', '.json'
+                '.pk9', '.cb9', '.pa9', '.pb8', '.pk8', '.pk7', '.pb7', '.pk6', '.pk5', '.pk4', '.pk3', '.dat', '.json', '.pkm'
             }
             
             for file_path in file_paths:
@@ -391,7 +391,8 @@ class PokemonHomeApp:
                 # Gen 3
                 '.pk3',
                 # Other
-                '.dat'
+                '.dat',
+                '.pkm'
             }
             processed_count = 0
             error_count = 0
@@ -416,7 +417,7 @@ class PokemonHomeApp:
                 else:
                     messagebox.showwarning(
                         "Unsupported File", 
-                        f"{os.path.basename(file_path)} is not a supported file type (.pk9, .cb9, .pa9, .pb8, .pk8, .dat)."
+                        f"{os.path.basename(file_path)} is not a supported file type (.pk9, .cb9, .pa9, .pb8, .pk8, .dat, .pkm)."
                     )
                     self.update_status(f"Import failed: Unsupported file type - {os.path.basename(file_path)}")
                     error_count += 1

--- a/Cobblemon Transporter/start.sh
+++ b/Cobblemon Transporter/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source venv/bin/activate
+python pokemonpc.py


### PR DESCRIPTION
Tested this, it works with importing .pkm (and presuambly other files) and it works with .cb9 export (i have no idea what that is, but i tested that it works with File -> Export to Pokemon), and it works with the "Showdown" button Export to Showdown too.

However, it doesn't work with the "Cobblemon" button, when I click that button and select my boxes .dat file, it says: Error process completed with message: JSON file selected - please select a Cobblemon .dat file to export to. Detected .dat type: boxes No existing Pokemon found to duplicate in boxes. Export failed.

also, when i try File -> Export to Cobblemon, it says: Detected .dat type: boxes
No existing Pokémon found to duplicate in boxes.
in the console, and an error window pops up with "Failed to load Pokemon data: 'shiny'"

I think most likely I'm not sure what the Cobblemon .dat files and the Cobblemon .json files it expects are, because I'm still new to Cobblemon I only just found out about it yesterday.

Also, this goes without saying but also this closes #4 

Maybe this won't be accepted because it's not interesting (or maybe it will be), and maybe I'll never learn what Cobblemon .dat files and Cobblemon .json files are and maybe I'll never figure out how to get genned mons into Cobblemon, but at least this should work well for anyone on Linux who does know how to do those things lol